### PR TITLE
Added possibility to block controllers

### DIFF
--- a/tgext/pluggable/adapt_controllers.py
+++ b/tgext/pluggable/adapt_controllers.py
@@ -25,7 +25,7 @@ class ControllersAdapter(object):
                 if isinstance(cont, tg.controllers.decoratedcontroller._DecoratedControllerMeta):
                     for n, c in cont.__dict__.items():
                         if hasattr(c, 'decoration') and c.decoration.exposed:
-                            if app_id == controller.get('path') and n == controller.get('name'):
+                            if n == controller:
                                 print "Blocked '%s' in '%s'" % (n, app_id)
                                 c.decoration.hooks['before_validate'] = [block_function]
 


### PR DESCRIPTION
Edit:
Giving the 'block_controllers' parameter to the plug function when plugging an application, you will retrieve your default 404 page when trying to access the method specified.

Syntax:

plug(base_config, '<PLUGGABLE APP>', '<PATH>',  <PARAMS>, block_controllers=['<CONTROLLER METHODS>'])

the <CONTROLLER METHODS> need to be comma separated, and need to contain the entire path if they are subcontroller's methods
