### PR TITLE
Fixed adapt_controllers.py to allow plugging app on deep paths

### DIFF
--- a/tgext/pluggable/adapt_controllers.py
+++ b/tgext/pluggable/adapt_controllers.py
@@ -9,7 +9,11 @@ class ControllersAdapter(object):
     def mount_controllers(self, app):
         root_controller = TGApp().find_controller('root')
         app_id = self.options['appid']
-
-        setattr(root_controller, app_id, self.controllers.RootController())
+        path = app_id.split('.')
+        route = path.pop(0)
+        while len(path)>0:
+            root_controller = getattr(root_controller, route)
+            route = path.pop(0)
+        setattr(root_controller, route, self.controllers.RootController())
 
         return app


### PR DESCRIPTION
You can now pass dotted mount path (Ex. "api.messages") to mount your pluggable apps in a deep path.
If an intermediate path is missing (Ex. "api.resources.messages" and /api/resources doesn't exists), it will raise an error when plugged, stopping the application launch.
If a controller is already mounted at the specified path, the route will be overwritten.
