### PR TITLE
Mounting the sub controller on the class rather than on the object

### DIFF
--- a/tgext/pluggable/adapt_controllers.py
+++ b/tgext/pluggable/adapt_controllers.py
@@ -12,14 +12,13 @@ class ControllersAdapter(object):
         
         try:
             route, name = app_id.rsplit('.', 1)
-            mountpoint = attrgetter(route)(root)
+            mountpoint = attrgetter(route)(root).__class__
         except ValueError:
             mountpoint, name = root, app_id
 
         return mountpoint, name
 
     def mount_controllers(self, app):
-        root_controller = TGApp().find_controller('root')
         app_id = self.options['appid']
 
         mountpoint, name = self._resolve_mountpoint(app_id)


### PR DESCRIPTION
Mounting the sub controller on the class to allow the sphinx extension to recognize plugged paths when generating docs.
