### PR TITLE
Python 3.x compatibility in template_replacements.init_replacements

### DIFF
--- a/tgext/pluggable/template_replacements.py
+++ b/tgext/pluggable/template_replacements.py
@@ -36,7 +36,7 @@ def init_replacements(app_config):
     except:
         templates_replacements = app_config._pluggable_templates_replacements = {}
 
-    for replaced_template, template in templates_replacements.iteritems():
+    for replaced_template, template in templates_replacements.items():
         if template in app_config.get('renderers', []):
             engine, template = template, ''
         elif ':' in template:


### PR DESCRIPTION
This code actually don't work with python 3, it is valid for you with this patch ?