### PR TITLE
crash loudly if a pluggable fails to being plugged

### DIFF
--- a/tgext/pluggable/plug.py
+++ b/tgext/pluggable/plug.py
@@ -149,6 +149,9 @@ class ApplicationPlugger(object):
                 else:
                     log.warning('%s helper already existing, skipping it' % name)
 
+
+    
+
             
 def plug(app_config, module_name, appid=None, **kwargs):
     plugged = init_pluggables(app_config)
@@ -178,4 +181,9 @@ def plug(app_config, module_name, appid=None, **kwargs):
     plugged['modules'][module_name] = {}
     plugger = ApplicationPlugger(plugged, app_config, module_name, options)
     app_config.register_hook('startup', plugger.plug)
-
+    
+    def fail_if_failed_to_plug(remainder, params):
+        if not plugged['modules'][module_name]:
+            raise RuntimeWarning('Check your log for errors '
+                                 'while plugging %s' % module_name)
+    app_config.register_hook('before_validate', fail_if_failed_to_plug)

--- a/tgext/pluggable/plug.py
+++ b/tgext/pluggable/plug.py
@@ -74,8 +74,11 @@ class ApplicationPlugger(object):
     def plug(self):
         try:
             self._plug_application(self.app_config, self.module_name, self.options)
-        except:
+        except Exception as e:
             log.exception('Failed to plug %s' % self.module_name)
+            def fail_if_failed_to_plug(remainder, params):
+                raise e
+            self.app_config.register_hook('before_validate', fail_if_failed_to_plug)
 
     def _plug_application(self, app_config, module_name, options):
         #In some cases the application is reloaded causing the startup hook to trigger again,
@@ -149,9 +152,6 @@ class ApplicationPlugger(object):
                 else:
                     log.warning('%s helper already existing, skipping it' % name)
 
-
-    
-
             
 def plug(app_config, module_name, appid=None, **kwargs):
     plugged = init_pluggables(app_config)
@@ -182,8 +182,3 @@ def plug(app_config, module_name, appid=None, **kwargs):
     plugger = ApplicationPlugger(plugged, app_config, module_name, options)
     app_config.register_hook('startup', plugger.plug)
     
-    def fail_if_failed_to_plug(remainder, params):
-        if not plugged['modules'][module_name]:
-            raise RuntimeWarning('Check your log for errors '
-                                 'while plugging %s' % module_name)
-    app_config.register_hook('before_validate', fail_if_failed_to_plug)

--- a/tgext/pluggable/plug.py
+++ b/tgext/pluggable/plug.py
@@ -78,7 +78,7 @@ class ApplicationPlugger(object):
             log.exception('Failed to plug %s' % self.module_name)
             def fail_if_failed_to_plug(remainder, params):
                 raise e
-            self.app_config.register_hook('before_validate', fail_if_failed_to_plug)
+            self.app_config.register_hook('before_call', fail_if_failed_to_plug)
 
     def _plug_application(self, app_config, module_name, options):
         #In some cases the application is reloaded causing the startup hook to trigger again,


### PR DESCRIPTION
crash loudly if a pluggable fails to being plugged, before that you would get cryptic errors all aroud, now the whole application stops